### PR TITLE
Ensure hero and best seller titles display in white

### DIFF
--- a/Frontend/src/Pages/HomePage.jsx
+++ b/Frontend/src/Pages/HomePage.jsx
@@ -13,13 +13,13 @@ export default function TestPage() {
         <div className="flex flex-col">
             {/* === SECTION HERO === */}
             <section className="bg-red-900 text-white text-center py-24 px-4">
-                <h1 className="text-4xl font-bold mb-4">DÉCOUVREZ VIB’IN</h1>
-                <p className="text-lg">L'harmonie parfaite entre musique et plaisir</p>
+                <h1 className="text-4xl font-bold mb-4 text-white">DÉCOUVREZ VIB’IN</h1>
+                <p className="text-lg text-white">L'harmonie parfaite entre musique et plaisir</p>
             </section>
 
             {/* === SECTION BEST SELLERS === */}
             <section className="py-16 px-4 text-center">
-                <h2 className="text-3xl font-semibold mb-8">BEST SELLERS</h2>
+                <h2 className="text-3xl font-semibold mb-8 text-white">BEST SELLERS</h2>
                 <div className="flex flex-wrap justify-center gap-6">
                     {PRODUCTS.map((p, index) => (
                         <div


### PR DESCRIPTION
## Summary
- adjust hero section headings to always render in white
- update Best Sellers section heading to white

## Testing
- `npm run lint` *(fails: node_modules/.bin/eslint not found)*

------
https://chatgpt.com/codex/tasks/task_b_68587c7151e48324bd17533f587c31ba